### PR TITLE
Add explicit dependency on base64

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,13 @@ PATH
   remote: .
   specs:
     starry (0.1.0)
+      base64
 
 GEM
   remote: https://rubygems.org/
   specs:
     base32 (0.3.4)
+    base64 (0.2.0)
     diff-lcs (1.5.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)

--- a/starry.gemspec
+++ b/starry.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/takemar/starry',
   }
   s.required_ruby_version = '>= 2.7.0'
+  s.add_runtime_dependency "base64"
 end


### PR DESCRIPTION
Hi,

I was testing starry on ruby HEAD and I noticed one of my gems (that depends on starry) was crashing when tested against current ruby development branch.

This is an example of the error I got:

https://github.com/nomadium/starry/actions/runs/8514153152/job/23319303325

```
/home/runner/.rubies/ruby-head/bin/ruby -I/home/runner/work/starry/starry/vendor/bundle/ruby/3.4.0+0/gems/rspec-core-3.12.2/lib:/home/runner/work/starry/starry/vendor/bundle/ruby/3.4.0+0/gems/rspec-support-3.12.1/lib /home/runner/work/starry/starry/vendor/bundle/ruby/3.4.0+0/gems/rspec-core-3.12.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

An error occurred while loading ./spec/httpwg_spec.rb. - Did you mean?
                    rspec ./spec/parse_httpwg_format.rb

Failure/Error: require 'base64'

LoadError:
  cannot load such file -- base64
# ./lib/starry.rb:1:in '<top (required)>'
# ./spec/parse_httpwg_format.rb:2:in '<top (required)>'
# ./spec/httpwg_spec.rb:2:in 'Kernel#require_relative'
# ./spec/httpwg_spec.rb:2:in '<top (required)>'


Top 0 slowest examples (0 seconds, 0.0% of total time):

Finished in 0.00003 seconds (files took 0.13471 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

```

It was easy to fix by just adding `base64` to the dependencies.

I also found that on Ruby 3.3.0 release notes there is a list of gems that will become bundled gems in the
future (next?) version of Ruby.

base64 is included in the above list mentioned and I guess that's why an explicit dependency is now required.

For more details, consult: https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

Without this commit, starry cannot be loaded and tested against ruby-head as of April 2024.