### PR TITLE
Fix nil handling in ASCII validation

### DIFF
--- a/lib/starry.rb
+++ b/lib/starry.rb
@@ -137,7 +137,7 @@ module Starry
     end
 
     private def ensure_ascii_only(input)
-      unless input.ascii_only?
+      unless input&.ascii_only?
         raise ParseError, "Input string contains unexpected non-ASCII character."
       end
     end


### PR DESCRIPTION
ensure_ascii_only previously assumed `input` was always a String. This caused NoMethodError when nil values were passed through.

Make validation nil-safe by using safe navigation so nil is handled consistently as invalid input and raises ParseError.